### PR TITLE
setting repo default

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,7 @@ inputs:
   repo:
     description: The repo where the GitHub files under groups are hosted.
     required: true
+    default: ${{ github.event.repository.name }}
   url:
     description: GitHub API URL if using GitHub Server or AE
     required: false


### PR DESCRIPTION
Can we use a default for the `repo` field?

```yml
default: ${{ github.event.repository.name }}
```

Would there be any case where that isn't part of the `github.event` property? 